### PR TITLE
Do not reuse socket

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '1.5'
+__version__ = '1.7'
 
 setup(
     name='pyialarm',


### PR DESCRIPTION
It has been reported that sometimes the alarm system replies are not
what we expected them to be.

To trigger this bug you need to create an IAlarm instance and call
"get_status()" in loop. Then with the official iAlarm application change
the alarm status from disarmed to armed.
At this point "get_status()" will start to complain that it doesn't
understand the alarm system replies.

By using a fresh new socket connection it seems like to be way safer and
this bug doesn't happen to present itself anymore.